### PR TITLE
Moved settings to G-Code and added filament specific settings

### DIFF
--- a/mmuGcodeParser.py
+++ b/mmuGcodeParser.py
@@ -21,6 +21,15 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 """
 
+"""
+@TODOs
+- Don't put debug output at last part in file (printer thinks file is incomplete)
+- Add sanity checks for temperatures
+- Add option to wait before toolchange/temp change to let the planner get empty and be in a stable state
+- Add option to wait for all temperatures to be stable before proceeding
+- Add option to overwrite file by moving new file to old file
+"""
+
 import re  # regular expression library for search/replace
 import os  # os routines for reading/writing files
 import sys  # system library for input/output files

--- a/mmuGcodeParser.py
+++ b/mmuGcodeParser.py
@@ -24,10 +24,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 """
 @TODOs
 - Don't put debug output at last part in file (printer thinks file is incomplete)
+- Modify "Wait for Dest Temp" to R instead of S
 - Add sanity checks for temperatures
 - Add option to wait before toolchange/temp change to let the planner get empty and be in a stable state
 - Add option to wait for all temperatures to be stable before proceeding
 - Add option to overwrite file by moving new file to old file
+- Add option to disable fan while tool changing
 """
 
 import re  # regular expression library for search/replace

--- a/mmuGcodeParser.py
+++ b/mmuGcodeParser.py
@@ -100,6 +100,8 @@ start = r"^; toolchange #[0-9]*"
 mmuGPDebug = r"^; MMUGP Debug"
 mmuGPRamTempDiff = r"^; MMUGP Ram Temp Diff ([0-9]*)"
 mmuGPRamTempDiffWaitStabilize = r"^; MMUPG Ram Temp Diff Wait For Stabilize"
+mmuGPFilenamePrefix = r"^; MMUGP Filename Prefix ?([a-zA-Z_-]*)"
+mmuGPFilenameSuffix = r"^; MMUGP Filename Suffix ?([a-zA-Z_-]*)"
 
 # turn those strings into compiled regular expressions so we can search
 start_detect = re.compile(start)
@@ -112,6 +114,8 @@ target_temp_detect = re.compile(targetTemp)
 mmugp_debug_detect = re.compile(mmuGPDebug)
 mmugp_ram_temp_diff_detect = re.compile(mmuGPRamTempDiff)
 mmugp_ram_temp_diff_wait_stabilize_detect = re.compile(mmuGPRamTempDiffWaitStabilize)
+mmugp_filename_prefix_detect = re.compile(mmuGPFilenamePrefix)
+mmugp_filename_suffix_detect = re.compile(mmuGPFilenameSuffix)
 
 """ 
 ### ---------------------------------------------------------------
@@ -421,6 +425,16 @@ for line in infile:
     ram_temp_diff_wait_for_stabilize_match = mmugp_ram_temp_diff_wait_stabilize_detect.search(line)
     if ram_temp_diff_wait_for_stabilize_match is not None:
         ram_temp_diff_wait_for_stabilize = True
+
+    # Search for Filename Prefix setting
+    filename_prefix_match = mmugp_filename_prefix_detect.search(line)
+    if filename_prefix_match is not None:
+        outpath_prefix = filename_prefix_match.group(1)
+
+    # Search for Filename Suffix setting
+    filename_suffix_match = mmugp_filename_suffix_detect.search(line)
+    if filename_suffix_match is not None:
+        outpath_suffix = filename_suffix_match.group(1)
 
     # increment the line number
     line_number = line_number + 1

--- a/mmuGcodeParser.py
+++ b/mmuGcodeParser.py
@@ -47,6 +47,8 @@ LOW2HIGH = "Low2High"
 HIGH2LOW = "High2Low"
 NOTRANSITION = "NoTrans"
 ID_LINE = "idLine"
+RAM_TEMP = "ramTemp"
+PURGE_TEMP = "purgeTemp"
 
 """ 
 ### ---------------------------------------------------------------
@@ -97,11 +99,17 @@ targetTemp = r"^M104 S([0-9]*)"
 start = r"^; toolchange #[0-9]*"
 
 # Regular expressions to find settings
+
+# Printer Start G-Code
 mmuGPDebug = r"^; MMUGP Debug"
 mmuGPRamTempDiff = r"^; MMUGP Ram Temp Diff ([0-9]*)"
 mmuGPRamTempDiffWaitStabilize = r"^; MMUPG Ram Temp Diff Wait For Stabilize"
 mmuGPFilenamePrefix = r"^; MMUGP Filename Prefix ?([a-zA-Z_-]*)"
 mmuGPFilenameSuffix = r"^; MMUGP Filename Suffix ?([a-zA-Z_-]*)"
+
+# Filament End G-Code
+mmuGPRamTemp = r"^; MMUGP Ram Temp ([0-9]*)"
+mmuGPPurgeTemp = r"^; MMUGP Purge Temp ([0-9]*)"
 
 # turn those strings into compiled regular expressions so we can search
 start_detect = re.compile(start)
@@ -116,6 +124,8 @@ mmugp_ram_temp_diff_detect = re.compile(mmuGPRamTempDiff)
 mmugp_ram_temp_diff_wait_stabilize_detect = re.compile(mmuGPRamTempDiffWaitStabilize)
 mmugp_filename_prefix_detect = re.compile(mmuGPFilenamePrefix)
 mmugp_filename_suffix_detect = re.compile(mmuGPFilenameSuffix)
+mmugp_ram_temp_detect = re.compile(mmuGPRamTemp)
+mmugp_purge_temp_detect = re.compile(mmuGPPurgeTemp)
 
 """ 
 ### ---------------------------------------------------------------
@@ -396,6 +406,18 @@ for line in infile:
         if len(myToolChanges) > 0:  # we have already at least one entry
             # remember the line number
             myToolChanges[toolChangeID][line_number] = UNLOAD_LINE
+
+    # Search for Ram Temp setting
+    ram_temp_match = mmugp_ram_temp_detect.search(line)
+    if ram_temp_match is not None:
+        if len(myToolChanges) > 0 and not RAM_TEMP in myToolChanges[toolChangeID]:
+            myToolChanges[toolChangeID][RAM_TEMP] = ram_temp_match.group(1)
+
+    # Search for Purge Temp setting
+    purge_temp_match = mmugp_purge_temp_detect.search(line)
+    if purge_temp_match is not None:
+        if len(myToolChanges) > 0 and not PURGE_TEMP in myToolChanges[toolChangeID]:
+            myToolChanges[toolChangeID][PURGE_TEMP] = purge_temp_match.group(1)
 
     # Search for the purge command
     purge_match = purge_detect.search(line)

--- a/mmuGcodeParser.py
+++ b/mmuGcodeParser.py
@@ -155,30 +155,31 @@ def low2high_handler(p_tool_change, p_line_number):
 
     lv_output = ""
     lv_insert = 0  # 0 = don't insert, +1 = after the line, -1 before the line, -9 = comment out
-    if p_tool_change[p_line_number] == UNLOAD_START_LINE:
+
+    if p_tool_change[UNLOAD_START_LINE] == p_line_number:
         # Add temp drop for better tip
         if ram_temp_diff > 0:  # Only if set
             lv_lower_temp = int(p_tool_change[CURR_TEMP]) - ram_temp_diff
             lv_output = "M104 S" + str(lv_lower_temp)
             lv_insert = 1
 
-    if p_tool_change[p_line_number] == DEST_TEMP_LINE:
+    if p_tool_change[DEST_TEMP_LINE] == p_line_number:
         # We need to stay cool here
         # remove/comment existing line
         lv_insert = -9
 
-    if p_tool_change[p_line_number] == UNLOAD_LINE:
+    if p_tool_change[UNLOAD_LINE] == p_line_number:
         # set hot (to save some time)
         # insert the destination temp
         lv_output = "M104 S" + p_tool_change[DEST_TEMP]
         lv_insert = -1  # insert before start unloading
 
-    if p_tool_change[p_line_number] == PURGE_LINE:
+    if p_tool_change[PURGE_LINE] == p_line_number:
         # We have to wait for destination temp
         lv_output = "M109 S" + p_tool_change[DEST_TEMP]
         lv_insert = 1  # insert after the purge line identificator
 
-    if p_tool_change[p_line_number] == PRINT_LINE:
+    if p_tool_change[PRINT_LINE] == p_line_number:
         # We are already hot. Nothing to do here
         pass
 
@@ -204,18 +205,19 @@ def high2low_handler(p_tool_change, p_line_number):
 
     lv_output = ""
     lv_insert = 0  # 0 = don't insert, +1 = after the line, -1 before the line, -9 = comment out
-    if p_tool_change[p_line_number] == UNLOAD_START_LINE:
+
+    if p_tool_change[UNLOAD_START_LINE] == p_line_number:
         if ram_temp_diff > 0:  # Only if set
             # Add temp drop for better tip
             lv_lower_temp = int(p_tool_change[CURR_TEMP]) - ram_temp_diff
             lv_output = "M104 S" + str(lv_lower_temp)
             lv_insert = 1  # after the line
 
-    if p_tool_change[p_line_number] == DEST_TEMP_LINE:
+    if p_tool_change[DEST_TEMP_LINE] == p_line_number:
         # remove/comment existing line
         lv_insert = -9
 
-    if p_tool_change[p_line_number] == UNLOAD_LINE:
+    if p_tool_change[UNLOAD_LINE] == p_line_number:
         # During unloading there is nothing to do
         # In case we are dropping the temp during ramming, we need to bump it up again
         if ram_temp_diff > 0:  # Only if set
@@ -223,12 +225,12 @@ def high2low_handler(p_tool_change, p_line_number):
             lv_insert = -1  # before the line
         pass
 
-    if p_tool_change[p_line_number] == PURGE_LINE:
+    if p_tool_change[PURGE_LINE] == p_line_number:
         # set to cold. We will cool down faster during purging
         lv_output = "M104 S" + p_tool_change[DEST_TEMP]
         lv_insert = 1  # after the line
 
-    if p_tool_change[p_line_number] == PRINT_LINE:
+    if p_tool_change[PRINT_LINE] == p_line_number:
         # wait for stable nozzle temp
         lv_output = "M109 S" + p_tool_change[DEST_TEMP]
         lv_insert = -1  # before the line
@@ -241,8 +243,9 @@ def none_handler(p_tool_change, p_line_number):
     # Just in case we need to do something at the end
     lv_output = ""
     lv_insert = 0  # 0 = don't insert, +1 = after the line, -1 before the line, -9 = comment out
+
     if CURR_TEMP in p_tool_change:
-        if p_tool_change[p_line_number] == UNLOAD_START_LINE:
+        if p_tool_change[UNLOAD_START_LINE] == p_line_number:
             if ram_temp_diff > 0:  # Only if set
                 # Add temp drop for better tip
                 lv_lower_temp = int(p_tool_change[CURR_TEMP]) - ram_temp_diff
@@ -254,7 +257,7 @@ def none_handler(p_tool_change, p_line_number):
                     lv_output = "M104 S" + str(lv_lower_temp)
                 lv_insert = 1  # after the line
 
-        if p_tool_change[p_line_number] == LOAD_START_LINE:
+        if p_tool_change[LOAD_START_LINE] == p_line_number:
             if ram_temp_diff > 0:  # Only if set
                 lv_restore_temp = int(p_tool_change[CURR_TEMP])
                 # don't wait for stable nozzle temperature
@@ -262,19 +265,19 @@ def none_handler(p_tool_change, p_line_number):
                 lv_output = "M104 S" + str(lv_restore_temp)
                 lv_insert = 1
 
-        if p_tool_change[p_line_number] == DEST_TEMP_LINE:
+        if p_tool_change[DEST_TEMP_LINE] == p_line_number:
             # nothing to do
             pass
 
-        if p_tool_change[p_line_number] == UNLOAD_LINE:
+        if p_tool_change[UNLOAD_LINE] == p_line_number:
             # nothing to do
             pass
 
-        if p_tool_change[p_line_number] == PURGE_LINE:
+        if p_tool_change[PURGE_LINE] == p_line_number:
             # nothing to do
             pass
 
-        if p_tool_change[p_line_number] == PRINT_LINE:
+        if p_tool_change[PRINT_LINE] == p_line_number:
             # nothing to do
             pass
 
@@ -358,7 +361,7 @@ for line in infile:
             switchID = start_position_match.group(0)
             # remember the tool change start position
             myToolChange["id"] = switchID
-            myToolChange[line_number] = ID_LINE
+            myToolChange[ID_LINE] = line_number
             toolChangeID = switchID  # Remember the last tool change ID for later reference
             # create dictionary entry
             myToolChanges[toolChangeID] = myToolChange
@@ -368,14 +371,14 @@ for line in infile:
     if before_unload_match is not None:
         if len(myToolChanges) > 0:  # we found at least the start tool change
             # remember the line number
-            myToolChanges[toolChangeID][line_number] = UNLOAD_START_LINE
+            myToolChanges[toolChangeID][UNLOAD_START_LINE] = line_number
 
     # Search for the 'before loading' position
     before_load_match = before_load_detect.search(line)
     if before_load_match is not None:
         if len(myToolChanges) > 0:  # we found at least the start tool change
             # remember the line number
-            myToolChanges[toolChangeID][line_number] = LOAD_START_LINE
+            myToolChanges[toolChangeID][LOAD_START_LINE] = line_number
 
     # Search for the target temperature
     targetTemp_match = target_temp_detect.search(line)
@@ -391,7 +394,7 @@ for line in infile:
                     # Remember the temperature
                     myToolChanges[toolChangeID][DEST_TEMP] = temp
                     # remember the line number
-                    myToolChanges[toolChangeID][line_number] = DEST_TEMP_LINE
+                    myToolChanges[toolChangeID][DEST_TEMP_LINE] = line_number
         else:
             # Search for the initial Temperature
             if initTemp == 0:
@@ -405,7 +408,7 @@ for line in infile:
     if unloading_match is not None:
         if len(myToolChanges) > 0:  # we have already at least one entry
             # remember the line number
-            myToolChanges[toolChangeID][line_number] = UNLOAD_LINE
+            myToolChanges[toolChangeID][UNLOAD_LINE] = line_number
 
     # Search for Ram Temp setting
     ram_temp_match = mmugp_ram_temp_detect.search(line)
@@ -424,14 +427,14 @@ for line in infile:
     if purge_match is not None:
         if len(myToolChanges) > 0:  # we have already at least one entry
             # remember the line number
-            myToolChanges[toolChangeID][line_number] = PURGE_LINE
+            myToolChanges[toolChangeID][PURGE_LINE] = line_number
 
     # Search for the print command
     print_match = print_detect.search(line)
     if print_match is not None:
         if len(myToolChanges) > 0:  # we have already at least one entry
             # remember the line number
-            myToolChanges[toolChangeID][line_number] = PRINT_LINE
+            myToolChanges[toolChangeID][PRINT_LINE] = line_number
 
     # Search for Debug setting
     debug_match = mmugp_debug_detect.search(line)


### PR DESCRIPTION
Hi.

I really love this script but I find it way to complicated if you want to change a single parameter. Therefore I modified the script to handle settings directly from G-Code. Also I added a simple progressbar because when processing large files it can take a while.

Also if you have any ideas to further improve the script.

TODOs:
- Add sanity checks for temperatures
- Add option to wait before toolchange/temp change to let the planner get empty and be in a stable state
- Add option to wait for all temperatures to be stable before proceeding

### Debug Mode

**Place**: Printer Start G-Code
**Description**: Enabled debug mode which prints out a nice summary of the tool changes at the bottom of the new G-Code file
**Default value**: off
**Example**:

`; MMUGP Debug`

### Ram Temp Diff

**Place**: Printer Start G-Code
**Description**: Sets the value of the temperature difference for ramming
**Default value**: 10
**Example**:

`; MMUGP Ram Temp Diff 10`

### Ram Temp Diff Wait For Stabilize

**Place**: Printer Start G-Code
**Description**: Enables waiting for ramming temperature (only on non transitioning changes)
**Default value**: Off
**Example**:

`; MMUPG Ram Temp Diff Wait For Stabilize`

### Filename Prefix

**Place**: Printer Start G-Code
**Description**: Sets the prefix of the newly generated G-Code file
**Default value**: None
**Example**:

`; MMUGP Filename Prefix MMUGP_`

### Filename Suffix

**Place**: Printer Start G-Code
**Description**: Sets the suffix of the newly generated G-Code file
**Default value**: _adjusted
**Example**:

`; MMUGP Filename Suffix _MySuffix`

**Detail**: If you want to turn off the suffix, just set it empty.

`; MMUGP Filename Suffix `

### Ram Temp

**Place**: Filament End G-Code
**Description**: Sets the ramming temperature for this specific filament
**Default value**: None
**Example**:

`; MMUGP Ram Temp 230`

**Detail**: With this setting you can set a specific temperature for ramming for a specific filament. This helps if you can't use the global "Ram Temp Diff" setting, because some of your filaments have a very different setting for ramming temperature.

### Purge Temp

**Place**: Filament End G-Code
**Description**: Sets the purge temperature for this specific filament
**Default value**: None
**Example**:

`; MMUGP Purge Temp 250`

**Detail**: With this setting you can set a specific temperature for purging for a specific filament. It only works on High to Low temperature transition. This is for example useful when you need 230°C for ramming PETG but to get all out of the nozzle afterwards you want 250°C before you switch to printing PLA at 215°C